### PR TITLE
Add cost-based drink pricing and fairer assignment system

### DIFF
--- a/tea-time-rotation/migration.sql
+++ b/tea-time-rotation/migration.sql
@@ -1,0 +1,45 @@
+-- drink_prices table
+CREATE TABLE drink_prices (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  drink_type TEXT NOT NULL,
+  sugar_level TEXT NOT NULL,
+  price INTEGER NOT NULL,
+  UNIQUE (drink_type, sugar_level)
+);
+
+-- Seed data
+INSERT INTO drink_prices (drink_type, sugar_level, price) VALUES
+  ('Tea', 'No Sugar', 24),
+  ('*', '*', 20);
+
+-- Add cost columns to users
+ALTER TABLE users ADD COLUMN total_cost_sponsored INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE users ADD COLUMN total_cost_consumed INTEGER NOT NULL DEFAULT 0;
+
+-- Backfill existing data
+UPDATE users SET
+  total_cost_consumed = drink_count * 20,
+  total_cost_sponsored = total_drinks_bought * 20;
+
+-- New RPC functions
+CREATE OR REPLACE FUNCTION increment_total_cost_sponsored(p_user_id UUID, p_amount INTEGER)
+RETURNS void AS $$
+  UPDATE users SET total_cost_sponsored = total_cost_sponsored + p_amount WHERE id = p_user_id;
+$$ LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION increment_total_cost_consumed(p_user_id UUID, p_amount INTEGER)
+RETURNS void AS $$
+  UPDATE users SET total_cost_consumed = total_cost_consumed + p_amount WHERE id = p_user_id;
+$$ LANGUAGE sql;
+
+-- Add permission
+-- IMPORTANT: Run these two statements separately (in separate SQL editor executions).
+-- PostgreSQL requires enum values to be committed before use.
+
+-- Step 1: Run this first, then click Run again for Step 2.
+ALTER TYPE permission ADD VALUE IF NOT EXISTS 'can_manage_prices';
+
+-- Step 2: Run this in a separate execution after Step 1 completes.
+INSERT INTO role_permissions (role_id, permission)
+SELECT id, 'can_manage_prices' FROM roles WHERE name = 'admin'
+ON CONFLICT DO NOTHING;

--- a/tea-time-rotation/src/App.tsx
+++ b/tea-time-rotation/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { supabase } from './supabaseClient';
 import OrderForm from './components/OrderForm';
 import Summary from './components/Summary';
@@ -12,6 +12,7 @@ import { usePinModal } from './hooks/usePinModal';
 import { useAuth } from './hooks/useAuth';
 import Auth from './components/Auth';
 import ChaiLytics from './components/ChaiLytics';
+import ManagePricesModal from './components/ManagePricesModal';
 import type { LeaderboardEntry } from './components/Leaderboard';
 
 interface Session {
@@ -34,6 +35,8 @@ interface User {
   roles: string[];
   total_drinks_bought: number;
   drink_count: number;
+  total_cost_sponsored: number;
+  total_cost_consumed: number;
   last_assigned_at: string | null;
   isActive: boolean;
 }
@@ -49,6 +52,9 @@ function App() {
   const { isModalOpen, openModal, closeModal: closeAddUserModal } = useAddUserModal();
   const { isPinModalOpen, onConfirm: onPinConfirm, showPinModal, closePinModal } = usePinModal();
   const [kettleClicks, setKettleClicks] = useState(0);
+  const [showAdminMenu, setShowAdminMenu] = useState(false);
+  const [showManagePricesModal, setShowManagePricesModal] = useState(false);
+  const adminMenuRef = useRef<HTMLDivElement>(null);
   const [topBuyers, setTopBuyers] = useState<LeaderboardEntry[]>([]);
   const [topDrinkers, setTopDrinkers] = useState<LeaderboardEntry[]>([]);
   const [showAssigneeModal, setShowAssigneeModal] = useState(false);
@@ -60,12 +66,34 @@ function App() {
     drinkerRank: number;
   } | null>(null);
 
+  // Close admin menu on outside click or Escape
+  useEffect(() => {
+    if (!showAdminMenu) return;
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setShowAdminMenu(false);
+    };
+
+    const handleOutsideClick = (e: MouseEvent) => {
+      if (adminMenuRef.current && !adminMenuRef.current.contains(e.target as Node)) {
+        setShowAdminMenu(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+    document.addEventListener('mousedown', handleOutsideClick);
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+      document.removeEventListener('mousedown', handleOutsideClick);
+    };
+  }, [showAdminMenu]);
+
   const fetchTopDrinkers = async () => {
     const { data } = await supabase
       .from('users')
-      .select('name, drink_count, total_drinks_bought')
+      .select('name, drink_count, total_drinks_bought, total_cost_sponsored, total_cost_consumed')
       .eq('isActive', true)
-      .order('drink_count', { ascending: false, nullsFirst: false })
+      .order('total_cost_consumed', { ascending: false, nullsFirst: false })
       .order('name', { ascending: true })
       .limit(3);
     if (data) {
@@ -76,9 +104,9 @@ function App() {
   const fetchLeaderboard = async () => {
     const { data } = await supabase
       .from('users')
-      .select('name, total_drinks_bought, drink_count')
+      .select('name, total_drinks_bought, drink_count, total_cost_sponsored, total_cost_consumed')
       .eq('isActive', true)
-      .order('total_drinks_bought', { ascending: false, nullsFirst: false })
+      .order('total_cost_sponsored', { ascending: false, nullsFirst: false })
       .order('name', { ascending: true })
       .limit(3);
     if (data) {
@@ -93,10 +121,9 @@ function App() {
     }
 
     try {
-      // Get current user's data
       const { data: userData, error: userError } = await supabase
         .from('users')
-        .select('name, total_drinks_bought, drink_count')
+        .select('name, total_drinks_bought, drink_count, total_cost_sponsored, total_cost_consumed')
         .eq('name', profile.name)
         .single();
 
@@ -105,19 +132,17 @@ function App() {
         return;
       }
 
-      // Get sponsor rank (count active users with more drinks bought)
       const { count: sponsorsAbove } = await supabase
         .from('users')
         .select('*', { count: 'exact', head: true })
         .eq('isActive', true)
-        .gt('total_drinks_bought', userData.total_drinks_bought || 0);
+        .gt('total_cost_sponsored', userData.total_cost_sponsored || 0);
 
-      // Get drinker rank (count active users with more drinks consumed)
       const { count: drinkersAbove } = await supabase
         .from('users')
         .select('*', { count: 'exact', head: true })
         .eq('isActive', true)
-        .gt('drink_count', userData.drink_count || 0);
+        .gt('total_cost_consumed', userData.total_cost_consumed || 0);
 
       setCurrentUserStats({
         userData: userData as LeaderboardEntry,
@@ -134,7 +159,7 @@ function App() {
     const fetchAllData = async (currentSession: Session) => {
       const [ordersData, usersData] = await Promise.all([
         supabase.from('orders').select('*').eq('session_id', currentSession.id),
-supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, profile_picture_url, total_drinks_bought, drink_count, last_assigned_at, isActive, roles:user_roles(roles(name))'),
+        supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, profile_picture_url, total_drinks_bought, drink_count, total_cost_sponsored, total_cost_consumed, last_assigned_at, isActive, roles:user_roles(roles(name))'),
       ]);
       if (ordersData.data) setOrders(ordersData.data);
       if (usersData.data) {
@@ -152,7 +177,7 @@ supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, p
       const { count } = await supabase
         .from('sessions')
         .select('*', { count: 'exact', head: true });
-      
+
       if (count) setTotalSessions(count);
 
       const { data: lastSession } = await supabase
@@ -167,14 +192,12 @@ supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, p
         setLastAssignee(lastSession.assignee_name);
       }
 
-      // First, try to find an active session
       const { data: sessionData, error } = await supabase
         .from('sessions')
         .select('*')
         .eq('status', 'active')
         .single();
 
-      // If no active session, check for a recently completed one
       if (!sessionData && (!error || error.code === 'PGRST116')) {
         const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
         const { data: completedData } = await supabase
@@ -240,12 +263,12 @@ supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, p
   const fetchAllData = async (currentSession: Session) => {
     const [ordersData, usersData] = await Promise.all([
       supabase.from('orders').select('*').eq('session_id', currentSession.id),
-      supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, profile_picture_url, total_drinks_bought, drink_count, last_assigned_at, isActive, roles:user_roles(roles(name))'),
+      supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, profile_picture_url, total_drinks_bought, drink_count, total_cost_sponsored, total_cost_consumed, last_assigned_at, isActive, roles:user_roles(roles(name))'),
     ]);
     if (ordersData.data) setOrders(ordersData.data);
     if (usersData.data) {
         const transformedUsers = usersData.data.map(user => {
-            const roles = Array.isArray(user.roles) 
+            const roles = Array.isArray(user.roles)
                 ? (user.roles as unknown as { roles: { name: string } }[]).map((r) => r.roles.name)
                 : [];
             return { ...user, roles };
@@ -277,12 +300,12 @@ supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, p
     };
   }, [session]);
 
-  // Helper function to calculate ratio
+  // Helper function to calculate ratio using costs
   const calculateRatio = (user: User) => {
-    if (user.total_drinks_bought > 0) {
-      return (user.drink_count / user.total_drinks_bought).toFixed(2);
+    if (user.total_cost_sponsored > 0) {
+      return (user.total_cost_consumed / user.total_cost_sponsored).toFixed(2);
     }
-    return user.drink_count > 0 ? '∞' : '0.00';
+    return user.total_cost_consumed > 0 ? '∞' : '0.00';
   };
 
   // Helper function to format last assigned date
@@ -316,12 +339,14 @@ supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, p
   };
 
   const handleKettleClick = () => {
-    if (profile?.permissions.includes('can_add_user')) {
+    const canAddUser = profile?.permissions.includes('can_add_user');
+    const canManagePrices = profile?.permissions.includes('can_manage_prices');
+    if (canAddUser || canManagePrices) {
       const newClicks = kettleClicks + 1;
       setKettleClicks(newClicks);
       if (newClicks >= 5) {
-        openModal();
-        setKettleClicks(0); // Reset after opening
+        setShowAdminMenu(true);
+        setKettleClicks(0);
       }
     }
   };
@@ -342,7 +367,6 @@ supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, p
       'This will complete the session and assign someone to make tea. Everyone will see the results.',
       async () => {
         try {
-          // Phase 1: Get candidate list
           const { data, error } = await supabase.functions.invoke('summarize', {
             body: { session_id: session.id },
           });
@@ -353,10 +377,9 @@ supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, p
             return;
           }
 
-          // Check if we need admin confirmation
           if (data?.requiresConfirmation && data?.candidates) {
             setCandidates(data.candidates);
-            setSelectedAssignee(data.candidates[0]?.id || ''); // Default to first candidate
+            setSelectedAssignee(data.candidates[0]?.id || '');
             setShowAssigneeModal(true);
           }
         } catch (err) {
@@ -376,7 +399,6 @@ supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, p
     }
 
     try {
-      // Phase 2: Commit with selected assignee
       const { data, error } = await supabase.functions.invoke('summarize', {
         body: { session_id: session.id, confirm_assignee: selectedAssignee },
       });
@@ -384,7 +406,6 @@ supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, p
       if (error) {
         console.error('Summarize function error:', error);
 
-        // Handle race condition specifically
         if (error.message?.includes('Session already summarized') ||
             error.message?.includes('already been completed')) {
           showError(
@@ -401,7 +422,6 @@ supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, p
       if (data?.committed) {
         setShowAssigneeModal(false);
 
-        // Force refresh the session data to get updated status
         const { data: updatedSession } = await supabase
           .from('sessions')
           .select('*')
@@ -432,7 +452,6 @@ supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, p
 
     showPinModal(async () => {
       try {
-        // First, delete all orders associated with the session
         const { error: deleteOrdersError } = await supabase
           .from('orders')
           .delete()
@@ -442,7 +461,6 @@ supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, p
           throw deleteOrdersError;
         }
 
-        // Then, delete the session itself
         const { error: deleteSessionError } = await supabase
           .from('sessions')
           .delete()
@@ -503,7 +521,7 @@ supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, p
       </div>
       {/* Enhanced Background for Better Visibility */}
       <div className="absolute inset-0 bg-gradient-to-br from-white via-primary-50 to-chai-100"></div>
-      
+
       {/* Subtle Tea Elements - Reduced for Better Visibility */}
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
         <div className="absolute top-10 left-10 text-4xl opacity-5 floating" style={{animationDelay: '0s'}}>🍃</div>
@@ -512,21 +530,44 @@ supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, p
         <div className="absolute bottom-20 right-32 text-2xl opacity-8 floating" style={{animationDelay: '1s'}}>🍃</div>
         <div className="absolute top-1/2 left-4 text-3xl opacity-5 floating" style={{animationDelay: '3s'}}>🍵</div>
       </div>
-      
+
       {/* Enhanced Mobile-Friendly Main Content */}
       <div className="relative z-10 min-h-screen flex flex-col items-center justify-center p-3 sm:p-6 lg:p-8 pt-24 sm:pt-6">
         {/* Enhanced Mobile-First Logo/Header Section */}
         <div className="text-center mb-6 sm:mb-8 animate-fade-in px-4">
-          <button
-            type="button"
-            className="relative inline-block"
-            onClick={handleKettleClick}
-            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleKettleClick(); } }}
-            aria-label="Open admin actions"
-          >
-            <div className="absolute -inset-4 bg-gradient-to-r from-primary-500 to-chai-500 rounded-full blur-lg opacity-20 animate-pulse-slow"></div>
-            <div className="relative text-6xl sm:text-7xl lg:text-8xl animate-bounce-subtle">🫖</div>
-          </button>
+          <div className="relative inline-block" ref={adminMenuRef}>
+            <button
+              type="button"
+              onClick={handleKettleClick}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleKettleClick(); } }}
+              aria-label="Open admin actions"
+            >
+              <div className="absolute -inset-4 bg-gradient-to-r from-primary-500 to-chai-500 rounded-full blur-lg opacity-20 animate-pulse-slow"></div>
+              <div className="relative text-6xl sm:text-7xl lg:text-8xl animate-bounce-subtle">🫖</div>
+            </button>
+
+            {/* Admin action menu */}
+            {showAdminMenu && (
+              <div className="absolute top-full left-1/2 -translate-x-1/2 mt-2 bg-white rounded-xl shadow-2xl border border-gray-200 z-50 min-w-[160px] overflow-hidden">
+                {profile?.permissions.includes('can_add_user') && (
+                  <button
+                    className="w-full px-4 py-3 text-left text-sm font-semibold text-gray-700 hover:bg-gray-50 flex items-center gap-2"
+                    onClick={() => { openModal(); setShowAdminMenu(false); }}
+                  >
+                    👤 Add User
+                  </button>
+                )}
+                {profile?.permissions.includes('can_manage_prices') && (
+                  <button
+                    className="w-full px-4 py-3 text-left text-sm font-semibold text-gray-700 hover:bg-gray-50 flex items-center gap-2"
+                    onClick={() => { setShowManagePricesModal(true); setShowAdminMenu(false); }}
+                  >
+                    💰 Manage Prices
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
           <h1 className="text-2xl sm:text-3xl lg:text-5xl font-bold text-gray-800 leading-tight mt-3 sm:mt-4 mb-2 drop-shadow-sm">
             Tea Time
           </h1>
@@ -539,10 +580,10 @@ supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, p
             {session ? (
               session.status === 'active' ? (
                 <div className="animate-slide-up">
-                  <OrderForm 
-                    session={session} 
-                    orders={orders} 
-                    users={users} 
+                  <OrderForm
+                    session={session}
+                    orders={orders}
+                    users={users}
                     onOrderUpdate={() => fetchAllData(session)}
                   />
                 </div>
@@ -564,7 +605,7 @@ supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, p
                     <h2 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">Ready for Tea Time?</h2>
                     <p className="text-gray-700 text-base sm:text-lg font-medium">Gather everyone and start brewing memories!</p>
                   </div>
-                  
+
                   <ChaiLytics
                     topSponsors={topBuyers}
                     topDrinkers={topDrinkers}
@@ -574,7 +615,7 @@ supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, p
                     currentUserStats={currentUserStats || undefined}
                   />
                 </div>
-                
+
                 <div className="flex flex-col items-center space-y-4">
                   <button
                     onClick={handleStartSession}
@@ -599,7 +640,7 @@ supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, p
                 </div>
               </div>
             )}
-            
+
             {session && session.status === 'active' && (
               <DangerZone title="Danger Zone">
                 <div className="pt-8 flex flex-col items-center space-y-4 animate-slide-up" style={{animationDelay: '0.2s'}}>
@@ -626,7 +667,7 @@ supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, p
             )}
           </div>
         </div>
-        
+
         {/* Enhanced Footer */}
         <footer className="text-center mt-12 px-4 animate-fade-in" style={{animationDelay: '0.5s'}}>
           <div className="bg-white/90 border-2 border-gray-200 rounded-2xl px-8 py-4 inline-block shadow-lg">
@@ -642,7 +683,7 @@ supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, p
           </div>
         </footer>
       </div>
-      
+
       {/* Subtle Pattern Overlay */}
       <div className="absolute inset-0 opacity-5 pointer-events-none">
         <div style={{
@@ -670,6 +711,11 @@ supabase.from('users').select('id, name, last_ordered_drink, last_sugar_level, p
         isOpen={isModalOpen}
         onClose={closeAddUserModal}
         onUserAdded={handleUserAdded}
+      />
+
+      <ManagePricesModal
+        isOpen={showManagePricesModal}
+        onClose={() => setShowManagePricesModal(false)}
       />
 
       <PinModal

--- a/tea-time-rotation/src/components/ChaiLytics.tsx
+++ b/tea-time-rotation/src/components/ChaiLytics.tsx
@@ -57,7 +57,7 @@ function ChaiLytics({ topSponsors, topDrinkers, totalSessions, lastAssignee, cur
         {activeTab === 'sponsors' && (
           <Leaderboard
             entries={topSponsors}
-            field="total_drinks_bought"
+            field="total_cost_sponsored"
             currentUserName={currentUserName}
             currentUserEntry={currentUserStats?.userData}
             currentUserRank={currentUserStats?.sponsorRank}
@@ -66,7 +66,7 @@ function ChaiLytics({ topSponsors, topDrinkers, totalSessions, lastAssignee, cur
         {activeTab === 'drinkers' && (
           <Leaderboard
             entries={topDrinkers}
-            field="drink_count"
+            field="total_cost_consumed"
             currentUserName={currentUserName}
             currentUserEntry={currentUserStats?.userData}
             currentUserRank={currentUserStats?.drinkerRank}

--- a/tea-time-rotation/src/components/Leaderboard.tsx
+++ b/tea-time-rotation/src/components/Leaderboard.tsx
@@ -1,14 +1,30 @@
 // No explicit React import needed with React 17+ JSX transform
+import { formatCost } from '../utils';
 
 export type LeaderboardEntry = {
   name: string;
   total_drinks_bought: number | null;
   drink_count: number | null;
+  total_cost_sponsored: number | null;
+  total_cost_consumed: number | null;
 };
+
+type CostField = 'total_cost_sponsored' | 'total_cost_consumed';
+type CountField = 'total_drinks_bought' | 'drink_count';
+type LeaderboardField = CountField | CostField;
+
+const COST_COUNT_MAP: Record<CostField, CountField> = {
+  total_cost_sponsored: 'total_drinks_bought',
+  total_cost_consumed: 'drink_count',
+};
+
+function isCostField(field: LeaderboardField): field is CostField {
+  return field === 'total_cost_sponsored' || field === 'total_cost_consumed';
+}
 
 interface LeaderboardProps {
   readonly entries: ReadonlyArray<LeaderboardEntry>;
-  readonly field: 'total_drinks_bought' | 'drink_count';
+  readonly field: LeaderboardField;
   readonly currentUserName?: string;
   readonly currentUserEntry?: LeaderboardEntry;
   readonly currentUserRank?: number;
@@ -26,8 +42,17 @@ const containerClassByIndex = (index: number): string => {
   return 'bg-amber-50 border-amber-200 text-amber-900';
 };
 
+function formatValue(entry: LeaderboardEntry, field: LeaderboardField): string {
+  if (isCostField(field)) {
+    const cost = entry[field] ?? 0;
+    const countField = COST_COUNT_MAP[field];
+    const count = entry[countField] ?? 0;
+    return `${formatCost(cost)} (${count})`;
+  }
+  return String(entry[field] ?? 0);
+}
+
 function Leaderboard({ entries, field, currentUserName, currentUserEntry, currentUserRank }: LeaderboardProps) {
-  // Check if current user is in the top 3
   const isCurrentUserInTop3 = currentUserName &&
     entries.some(entry => entry.name === currentUserName);
 
@@ -49,12 +74,11 @@ function Leaderboard({ entries, field, currentUserName, currentUserEntry, curren
                 <span className="font-medium">{entry.name}</span>
               </div>
               <div className="text-sm">
-                <span className="font-semibold">{entry[field] ?? 0}</span>
+                <span className="font-semibold">{formatValue(entry, field)}</span>
               </div>
             </div>
           ))}
 
-          {/* Show current user's row if not in top 3 */}
           {!isCurrentUserInTop3 && currentUserEntry && currentUserRank && (
             <div className="bg-gray-100 border-2 border-gray-300 rounded-lg px-3 py-2 mt-3">
               <div className="flex items-center justify-between">
@@ -68,7 +92,7 @@ function Leaderboard({ entries, field, currentUserName, currentUserEntry, curren
                 </div>
                 <div className="text-sm">
                   <span className="font-semibold text-gray-700">
-                    {currentUserEntry[field] ?? 0}
+                    {formatValue(currentUserEntry, field)}
                   </span>
                 </div>
               </div>

--- a/tea-time-rotation/src/components/ManagePricesModal.tsx
+++ b/tea-time-rotation/src/components/ManagePricesModal.tsx
@@ -1,0 +1,189 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '../supabaseClient';
+import { useAuth } from '../hooks/useAuth';
+
+interface DrinkPrice {
+  id: string;
+  drink_type: string;
+  sugar_level: string;
+  price: number;
+}
+
+interface ManagePricesModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const DRINK_TYPES = ['Tea', 'Coffee', 'Black Coffee', 'Black Tea', 'Lemon Tea', 'Plain Milk', 'Badam Milk', '*'];
+const SUGAR_LEVELS = ['No Sugar', 'Less', 'Normal', '*'];
+
+const ManagePricesModal = ({ isOpen, onClose }: ManagePricesModalProps) => {
+  const { profile } = useAuth();
+  const [prices, setPrices] = useState<DrinkPrice[]>([]);
+  const [newDrink, setNewDrink] = useState('Tea');
+  const [newSugar, setNewSugar] = useState('Normal');
+  const [newPrice, setNewPrice] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [editingPrices, setEditingPrices] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (isOpen) fetchPrices();
+  }, [isOpen]);
+
+  const fetchPrices = async () => {
+    const { data } = await supabase
+      .from('drink_prices')
+      .select('*')
+      .order('drink_type')
+      .order('sugar_level');
+    if (data) setPrices(data as DrinkPrice[]);
+  };
+
+  if (!isOpen || !profile?.permissions.includes('can_manage_prices')) return null;
+
+  const handleAddOrUpdate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const priceNum = parseInt(newPrice);
+    if (!newPrice || isNaN(priceNum) || priceNum < 0) {
+      setError('Enter a valid price.');
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    const { error: upsertError } = await supabase
+      .from('drink_prices')
+      .upsert(
+        { drink_type: newDrink, sugar_level: newSugar, price: priceNum },
+        { onConflict: 'drink_type,sugar_level' }
+      );
+    if (upsertError) {
+      setError(upsertError.message);
+    } else {
+      setNewPrice('');
+      fetchPrices();
+    }
+    setIsLoading(false);
+  };
+
+  const handlePriceEdit = async (id: string, drinkType: string, sugarLevel: string) => {
+    const val = editingPrices[id];
+    if (val === undefined) return;
+    const priceNum = parseInt(val);
+    if (isNaN(priceNum) || priceNum < 0) return;
+    await supabase
+      .from('drink_prices')
+      .upsert(
+        { drink_type: drinkType, sugar_level: sugarLevel, price: priceNum },
+        { onConflict: 'drink_type,sugar_level' }
+      );
+    fetchPrices();
+    setEditingPrices(prev => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 transition-all duration-300 opacity-100">
+      <div className="absolute inset-0 bg-black opacity-50" onClick={onClose} />
+      <div className="relative bg-white rounded-2xl shadow-2xl max-w-lg w-full mx-4 transform transition-all duration-300 scale-100 translate-y-0 max-h-[90vh] flex flex-col">
+        <div className="bg-gradient-to-r from-green-500 to-green-600 rounded-t-2xl p-4 text-center">
+          <h3 className="text-xl font-bold text-white">Manage Drink Prices</h3>
+        </div>
+        <div className="p-6 overflow-y-auto flex-1">
+          <h4 className="font-semibold text-gray-700 mb-3">Current Prices</h4>
+          <div className="space-y-2 mb-6">
+            {prices.length === 0 ? (
+              <p className="text-gray-500 text-sm">No prices set yet.</p>
+            ) : (
+              prices.map(p => (
+                <div key={p.id} className="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
+                  <div className="text-sm font-medium text-gray-800">
+                    <span className="font-bold">{p.drink_type === '*' ? '* (all drinks)' : p.drink_type}</span>
+                    {' / '}
+                    <span>{p.sugar_level === '*' ? '* (all sugars)' : p.sugar_level}</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="number"
+                      className="w-20 px-2 py-1 border border-gray-300 rounded text-sm text-right focus:outline-none focus:ring-2 focus:ring-green-500"
+                      value={editingPrices[p.id] !== undefined ? editingPrices[p.id] : p.price}
+                      onChange={e => setEditingPrices(prev => ({ ...prev, [p.id]: e.target.value }))}
+                      onBlur={() => handlePriceEdit(p.id, p.drink_type, p.sugar_level)}
+                      min="0"
+                    />
+                    <span className="text-gray-500 text-sm">₹</span>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+
+          <h4 className="font-semibold text-gray-700 mb-3">Add / Update Price</h4>
+          <form onSubmit={handleAddOrUpdate} className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="text-xs text-gray-600 font-medium">Drink Type</label>
+                <select
+                  value={newDrink}
+                  onChange={e => setNewDrink(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-green-500 mt-1"
+                >
+                  {DRINK_TYPES.map(d => (
+                    <option key={d} value={d}>{d === '*' ? '* (wildcard)' : d}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="text-xs text-gray-600 font-medium">Sugar Level</label>
+                <select
+                  value={newSugar}
+                  onChange={e => setNewSugar(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-green-500 mt-1"
+                >
+                  {SUGAR_LEVELS.map(s => (
+                    <option key={s} value={s}>{s === '*' ? '* (wildcard)' : s}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div>
+              <label className="text-xs text-gray-600 font-medium">Price (₹)</label>
+              <input
+                type="number"
+                value={newPrice}
+                onChange={e => setNewPrice(e.target.value)}
+                placeholder="e.g. 20"
+                min="0"
+                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500 mt-1 text-sm"
+                disabled={isLoading}
+              />
+            </div>
+            {error && <p className="text-red-500 text-sm">{error}</p>}
+            <div className="flex justify-end space-x-3 pt-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-4 py-2 text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-xl font-semibold transition-colors duration-200 text-sm"
+                disabled={isLoading}
+              >
+                Close
+              </button>
+              <button
+                type="submit"
+                className="px-6 py-2 bg-gradient-to-r from-green-500 to-green-600 text-white rounded-xl font-semibold hover:opacity-90 transition-opacity duration-200 text-sm"
+                disabled={isLoading}
+              >
+                {isLoading ? 'Saving...' : 'Save Price'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ManagePricesModal;

--- a/tea-time-rotation/src/components/OrderForm.tsx
+++ b/tea-time-rotation/src/components/OrderForm.tsx
@@ -5,6 +5,7 @@ import { useModal } from '../hooks/useModal';
 import AddUserModal from './AddUserModal';
 import { useAddUserModal } from '../hooks/useAddUserModal';
 import { useAuth } from '../hooks/useAuth';
+import { resolvePrice, type DrinkPrice } from '../utils';
 
 interface User {
   id: string;
@@ -41,6 +42,7 @@ const OrderForm = ({ session, orders, users, onOrderUpdate }: OrderFormProps) =>
   const [drinkType, setDrinkType] = useState('Tea');
   const [sugarLevel, setSugarLevel] = useState('Normal');
   const [isExcused, setIsExcused] = useState(false);
+  const [drinkPrices, setDrinkPrices] = useState<DrinkPrice[]>([]);
   const { isOpen, config, onConfirm, closeModal, showError, showSuccess, showConfirm } = useModal();
   const { isModalOpen, openModal, closeModal: closeAddUserModal } = useAddUserModal();
   const [kettleClicks, setKettleClicks] = useState(0);
@@ -49,6 +51,12 @@ const OrderForm = ({ session, orders, users, onOrderUpdate }: OrderFormProps) =>
   const longPressTimerRef = useRef<NodeJS.Timeout | null>(null);
   const longPressTriggeredRef = useRef(false);
   const [showUserStats, setShowUserStats] = useState<User | null>(null);
+
+  useEffect(() => {
+    supabase.from('drink_prices').select('*').then(({ data }) => {
+      if (data) setDrinkPrices(data as DrinkPrice[]);
+    });
+  }, []);
 
   useEffect(() => {
     if (selectedUser) {
@@ -510,6 +518,15 @@ const OrderForm = ({ session, orders, users, onOrderUpdate }: OrderFormProps) =>
             ))}
           </div>
         </div>
+
+        {/* Price preview */}
+        {drinkPrices.length > 0 && (
+          <div className="text-center py-2">
+            <span className="inline-block bg-green-50 border border-green-200 rounded-full px-4 py-1 text-sm font-semibold text-green-800">
+              💰 Price: ₹{resolvePrice(drinkType, sugarLevel, drinkPrices)}
+            </span>
+          </div>
+        )}
 
         {/* Enhanced Mobile-Friendly Action Buttons */}
         <div className="space-y-6 pt-8 animate-slide-up" style={{animationDelay: '0.3s'}}>

--- a/tea-time-rotation/src/components/Summary.tsx
+++ b/tea-time-rotation/src/components/Summary.tsx
@@ -4,6 +4,7 @@ import Modal from './ui/Modal';
 import ChaiLytics from './ChaiLytics';
 import type { LeaderboardEntry } from './Leaderboard';
 import { useAuth } from '../hooks/useAuth';
+import { resolvePrice, formatCost, type DrinkPrice } from '../utils';
 
 interface User {
   name: string;
@@ -32,6 +33,7 @@ const Summary = ({ session, onNewSession }: SummaryProps) => {
   const [orders, setOrders] = useState<Order[]>([]);
   const [assignee, setAssignee] = useState<string | null>(null);
   const [summarizedBy, setSummarizedBy] = useState<string | null>(null);
+  const [drinkPrices, setDrinkPrices] = useState<DrinkPrice[]>([]);
   const [isChaiLyticsOpen, setIsChaiLyticsOpen] = useState(false);
   const [chaiLyticsData, setChaiLyticsData] = useState<{
     topSponsors: LeaderboardEntry[];
@@ -57,16 +59,16 @@ const Summary = ({ session, onNewSession }: SummaryProps) => {
   const fetchChaiLyticsData = async () => {
     const { data: topSponsors } = await supabase
       .from('users')
-      .select('name, total_drinks_bought, drink_count')
+      .select('name, total_drinks_bought, drink_count, total_cost_sponsored, total_cost_consumed')
       .eq('isActive', true)
-      .order('total_drinks_bought', { ascending: false })
+      .order('total_cost_sponsored', { ascending: false })
       .limit(3);
 
     const { data: topDrinkers } = await supabase
       .from('users')
-      .select('name, total_drinks_bought, drink_count')
+      .select('name, total_drinks_bought, drink_count, total_cost_sponsored, total_cost_consumed')
       .eq('isActive', true)
-      .order('drink_count', { ascending: false })
+      .order('total_cost_consumed', { ascending: false })
       .limit(3);
 
     const { count: totalSessions } = await supabase
@@ -88,7 +90,7 @@ const Summary = ({ session, onNewSession }: SummaryProps) => {
       try {
         const { data: userData } = await supabase
           .from('users')
-          .select('name, total_drinks_bought, drink_count')
+          .select('name, total_drinks_bought, drink_count, total_cost_sponsored, total_cost_consumed')
           .eq('name', profile.name)
           .single();
 
@@ -97,13 +99,13 @@ const Summary = ({ session, onNewSession }: SummaryProps) => {
             .from('users')
             .select('*', { count: 'exact', head: true })
             .eq('isActive', true)
-            .gt('total_drinks_bought', userData.total_drinks_bought || 0);
+            .gt('total_cost_sponsored', userData.total_cost_sponsored || 0);
 
           const { count: drinkersAbove } = await supabase
             .from('users')
             .select('*', { count: 'exact', head: true })
             .eq('isActive', true)
-            .gt('drink_count', userData.drink_count || 0);
+            .gt('total_cost_consumed', userData.total_cost_consumed || 0);
 
           currentUserStats = {
             userData: userData as LeaderboardEntry,
@@ -132,13 +134,12 @@ const Summary = ({ session, onNewSession }: SummaryProps) => {
 
   useEffect(() => {
     const fetchOrders = async () => {
-      const { data } = await supabase
-        .from('orders')
-        .select('*, users(name)')
-        .eq('session_id', session.id);
-      if (data) {
-        setOrders(data as Order[]);
-      }
+      const [ordersResult, pricesResult] = await Promise.all([
+        supabase.from('orders').select('*, users(name)').eq('session_id', session.id),
+        supabase.from('drink_prices').select('*'),
+      ]);
+      if (ordersResult.data) setOrders(ordersResult.data as Order[]);
+      if (pricesResult.data) setDrinkPrices(pricesResult.data as DrinkPrice[]);
     };
 
     const fetchAssignee = async () => {
@@ -244,8 +245,13 @@ const Summary = ({ session, onNewSession }: SummaryProps) => {
               <span className="mr-3 text-3xl">📊</span>
               Order Analytics
             </h3>
-            <div className="inline-flex items-center space-x-3 bg-gradient-to-r from-secondary-100 to-matcha-100 rounded-full px-6 py-2">
-              <span className="text-gray-700 font-semibold text-lg">Total Drinks : {orders.length}</span>
+            <div className="inline-flex items-center space-x-3 bg-gradient-to-r from-secondary-100 to-matcha-100 rounded-full px-6 py-2 flex-wrap gap-2 justify-center">
+              <span className="text-gray-700 font-semibold text-lg">Total Drinks: {orders.length}</span>
+              {drinkPrices.length > 0 && (
+                <span className="text-green-700 font-semibold text-lg">
+                  · {formatCost(orders.reduce((sum, o) => sum + resolvePrice(o.drink_type, o.sugar_level, drinkPrices), 0))}
+                </span>
+              )}
             </div>
           </div>
 
@@ -275,10 +281,13 @@ const Summary = ({ session, onNewSession }: SummaryProps) => {
                       </div>
                       <div>
                         <span className="font-bold text-gray-900">{drink}</span>
-                        <div className="flex space-x-1 mt-1">
+                        <div className="flex space-x-1 mt-1 flex-wrap gap-1">
                           {Object.entries(sugarLevels).map(([sugar, count]) => (
                             <span key={sugar} className="text-sm bg-gray-100 border border-gray-300 rounded-full px-2 py-1 font-medium">
                               {sugarMap[sugar] || '?'}×{count}
+                              {drinkPrices.length > 0 && (
+                                <span className="text-green-700 ml-1">₹{resolvePrice(drink, sugar, drinkPrices)}</span>
+                              )}
                             </span>
                           ))}
                         </div>

--- a/tea-time-rotation/src/utils.ts
+++ b/tea-time-rotation/src/utils.ts
@@ -1,0 +1,21 @@
+export interface DrinkPrice {
+  drink_type: string;
+  sugar_level: string;
+  price: number;
+}
+
+export function formatCost(amount: number): string {
+  return amount.toLocaleString('en-IN') + '₹';
+}
+
+export function resolvePrice(drink: string, sugar: string, prices: DrinkPrice[]): number {
+  const exact = prices.find(p => p.drink_type === drink && p.sugar_level === sugar);
+  if (exact) return exact.price;
+  const drinkWild = prices.find(p => p.drink_type === drink && p.sugar_level === '*');
+  if (drinkWild) return drinkWild.price;
+  const wildSugar = prices.find(p => p.drink_type === '*' && p.sugar_level === sugar);
+  if (wildSugar) return wildSugar.price;
+  const wildWild = prices.find(p => p.drink_type === '*' && p.sugar_level === '*');
+  if (wildWild) return wildWild.price;
+  return 20;
+}

--- a/tea-time-rotation/supabase/functions/summarize/index.ts
+++ b/tea-time-rotation/supabase/functions/summarize/index.ts
@@ -7,6 +7,24 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
+interface DrinkPrice {
+  drink_type: string;
+  sugar_level: string;
+  price: number;
+}
+
+function resolvePrice(drink: string, sugar: string, prices: DrinkPrice[]): number {
+  const exact = prices.find(p => p.drink_type === drink && p.sugar_level === sugar);
+  if (exact) return exact.price;
+  const drinkWild = prices.find(p => p.drink_type === drink && p.sugar_level === '*');
+  if (drinkWild) return drinkWild.price;
+  const wildSugar = prices.find(p => p.drink_type === '*' && p.sugar_level === sugar);
+  if (wildSugar) return wildSugar.price;
+  const wildWild = prices.find(p => p.drink_type === '*' && p.sugar_level === '*');
+  if (wildWild) return wildWild.price;
+  return 20;
+}
+
 Deno.serve(async (req) => {
   const supabase = createClient(
     Deno.env.get('SUPABASE_URL')!,
@@ -48,10 +66,10 @@ Deno.serve(async (req) => {
 
   const users = orders.map(order => order.users);
 
-  // Sort by drink_count/total_drinks_bought ratio (desc) and then by last_assigned_at (asc)
+  // Sort by total_cost_consumed/total_cost_sponsored ratio (desc) and then by last_assigned_at (asc)
   users.sort((a, b) => {
-    const ratioA = a.total_drinks_bought > 0 ? a.drink_count / a.total_drinks_bought : (a.drink_count > 0 ? Infinity : 0);
-    const ratioB = b.total_drinks_bought > 0 ? b.drink_count / b.total_drinks_bought : (b.drink_count > 0 ? Infinity : 0);
+    const ratioA = a.total_cost_sponsored > 0 ? a.total_cost_consumed / a.total_cost_sponsored : (a.total_cost_consumed > 0 ? Infinity : 0);
+    const ratioB = b.total_cost_sponsored > 0 ? b.total_cost_consumed / b.total_cost_sponsored : (b.total_cost_consumed > 0 ? Infinity : 0);
 
     if (ratioA !== ratioB) {
       return ratioB - ratioA; // Sort descending by ratio
@@ -99,7 +117,6 @@ Deno.serve(async (req) => {
   }
 
   // Atomic update: only succeeds if status is still 'active'
-  // This acts as a lock - only ONE request can successfully transition from active to completed
   const { data: updatedSession, error: sessionUpdateError } = await supabase
     .from('sessions')
     .update({
@@ -115,7 +132,6 @@ Deno.serve(async (req) => {
 
   // Check if the update succeeded
   if (!updatedSession || updatedSession.length === 0) {
-    // Session was already completed by another request
     return new Response(
       JSON.stringify({
         error: 'Session already summarized',
@@ -123,7 +139,7 @@ Deno.serve(async (req) => {
       }),
       {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        status: 409,  // Conflict
+        status: 409,
       }
     );
   }
@@ -138,8 +154,9 @@ Deno.serve(async (req) => {
     );
   }
 
-  // If we reach here, we successfully claimed the session completion
-  // Now proceed with user updates...
+  // Fetch drink prices for cost resolution
+  const { data: drinkPricesData } = await supabase.from('drink_prices').select('*');
+  const prices: DrinkPrice[] = drinkPricesData || [];
 
   // Update last order details for each user
   for (const order of orders) {
@@ -160,10 +177,12 @@ Deno.serve(async (req) => {
     }
   }
 
-  // Increment drink_count for all participating users
+  // Increment drink_count and total_cost_consumed for all participating users
   for (const order of orders) {
     if (order.user_id) {
       await supabase.rpc('increment_drink_count', { user_id: order.user_id });
+      const price = resolvePrice(order.drink_type, order.sugar_level, prices);
+      await supabase.rpc('increment_total_cost_consumed', { p_user_id: order.user_id, p_amount: price });
     }
   }
 
@@ -173,6 +192,10 @@ Deno.serve(async (req) => {
     .eq('id', assignee.id);
 
   await supabase.rpc('increment_total_drinks_bought', { p_user_id: assignee.id, p_amount: orders.length });
+
+  // Increment total_cost_sponsored for assignee (total session cost)
+  const totalSessionCost = orders.reduce((sum, order) => sum + resolvePrice(order.drink_type, order.sugar_level, prices), 0);
+  await supabase.rpc('increment_total_cost_sponsored', { p_user_id: assignee.id, p_amount: totalSessionCost });
 
   return new Response(JSON.stringify({ assignee, committed: true }), {
     headers: { ...corsHeaders, 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- Add `drink_prices` table with wildcard price resolution (exact > drink+* > *+sugar > *+*)
- Track `total_cost_sponsored` / `total_cost_consumed` per user; backfill at ₹20/drink
- Summarize function now uses cost ratio for candidate ranking and updates cost fields on session close
- Leaderboard/ChaiLytics display cost as `1,480₹ (74)` format
- OrderForm shows resolved price per selected drink/sugar combo
- Summary shows unit price per combo and total session cost
- `ManagePricesModal` for admins (accessed via 5-click kettle menu → "Manage Prices")

## Test plan
- [ ] Run `migration.sql` in Supabase (in two steps for the enum addition)
- [ ] Deploy `summarize` edge function
- [ ] Order form shows price badge after selecting drink + sugar
- [ ] Summary shows ₹ prices and total session cost
- [ ] Leaderboard shows `₹X (N)` format in both tabs
- [ ] Admin: 5-click kettle shows dropdown with "Add User" and "Manage Prices"
- [ ] Manage Prices modal: inline edit and add/update work correctly
- [ ] Summarize updates cost fields correctly for all users and assignee

🤖 Generated with [Claude Code](https://claude.com/claude-code)